### PR TITLE
Fix Express and React router conflict

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -154,7 +154,9 @@ function loadClient(app) {
         })
     );
     // Always set root endpoint to serve client html
-    app.get("/", (req, res) => {
+    // Serving the html to every request and let react router deal with
+    // the path in the browser
+    app.get("*", (req, res) => {
         res.sendFile(path.resolve(__dirname, "../assets/index.html"));
     });
     return app;


### PR DESCRIPTION
When refreshing the page in the production environment, the app fails with the message

```
Cannot GET /personality/5ebdd0c09f9292005890d4c4
```

Because there is a conflict between react-router and express routes, this is addressed by serving the static html to every route using a wild card.