### PR TITLE
Display personality card according to layout

### DIFF
--- a/src/api/personality.js
+++ b/src/api/personality.js
@@ -1,11 +1,12 @@
 import axios from "axios";
 
-const getPersonalities = (options, dispatch) => {
-    const { page, searchName, pageSize } = options || {};
+const getPersonalities = (options = {}, dispatch) => {
     const params = {
-        page: page - 1,
-        name: searchName,
-        pageSize
+        page: options.page - 1,
+        name: options.searchName,
+        pageSize: options.pageSize,
+        language:
+            options.i18n && options.i18n.languages && options.i18n.languages[0]
     };
 
     axios

--- a/src/components/Claim/ClaimCard.jsx
+++ b/src/components/Claim/ClaimCard.jsx
@@ -1,0 +1,51 @@
+import { Avatar, Button, Col, Comment, Row, Tooltip } from "antd";
+import React from "react";
+
+function ClaimCard(props) {
+    return (
+        <Col span={24}>
+            <Comment
+                style={{ margin: "0px 20px" }}
+                key={props.claimIndex}
+                author={props.personality.name}
+                avatar={
+                    <Avatar
+                        src={props.personality.image}
+                        alt={props.personality.name}
+                    />
+                }
+                content={
+                    <>
+                        <Row>
+                            <Col>
+                                <p>{props.claim.title}</p>
+                            </Col>
+                        </Row>
+                        <Row>
+                            <Col offset={16}>
+                                <Button
+                                    shape="round"
+                                    type="primary"
+                                    onClick={e => {
+                                        e.stopPropagation();
+                                        props.viewClaim(props.claim._id);
+                                    }}
+                                >
+                                    Revisar
+                                </Button>
+                            </Col>
+                        </Row>
+                    </>
+                }
+                datetime={
+                    <Tooltip title="01/2020">
+                        <span>há 5 meses</span>
+                    </Tooltip>
+                }
+            />
+            <hr style={{ opacity: "20%" }} />
+        </Col>
+    );
+}
+
+export default ClaimCard;

--- a/src/components/Personality/PersonalityCard.jsx
+++ b/src/components/Personality/PersonalityCard.jsx
@@ -1,33 +1,53 @@
 import React, { Component } from "react";
-import { withRouter } from "react-router-dom";
-import axios from "axios";
-import { Avatar, Spin, Table, Col, Row, Typography } from "antd";
+import { Avatar, Spin, Col, Row, Typography, Button } from "antd";
+import { withTranslation } from "react-i18next";
 
 const { Title, Paragraph } = Typography;
-const { Column } = Table;
 
 class PersonalityCard extends Component {
     constructor(props) {
         super(props);
+        if (this.props.summarized) {
+            this.titleSpan = 13;
+            this.avatarSpan = 2;
+            this.avatarSize = 45;
+        } else {
+            this.titleSpan = 15;
+            this.avatarSpan = 6;
+            this.avatarSize = 90;
+        }
     }
 
     render() {
-        const personality = this.props.personality;
+        const { personality, t } = this.props;
 
         if (personality) {
             return (
                 <>
                     <Row style={{ padding: "10px 30px", marginTop: "10px" }}>
-                        <Col span={6}>
-                            <Avatar size={90} src={personality.image} />
+                        <Col span={this.avatarSpan}>
+                            <Avatar
+                                size={this.avatarSize}
+                                src={personality.image}
+                            />
                         </Col>
                         <Col span={3}></Col>
-                        <Col span={15}>
+                        <Col span={this.titleSpan}>
                             <Title level={4}>{personality.name}</Title>
                             <Paragraph ellipsis={{ rows: 1, expandable: true }}>
                                 {personality.description}
                             </Paragraph>
                         </Col>
+                        {this.props.summarized && (
+                            <Col span={6}>
+                                <Button
+                                    type="primary"
+                                    href={`personality/${personality._id}`}
+                                >
+                                    {t("personality:profile_button")}
+                                </Button>
+                            </Col>
+                        )}
                     </Row>
                     <hr style={{ opacity: "20%" }} />
                 </>
@@ -48,4 +68,4 @@ class PersonalityCard extends Component {
     }
 }
 
-export default PersonalityCard;
+export default withTranslation()(PersonalityCard);

--- a/src/components/Personality/PersonalityList.jsx
+++ b/src/components/Personality/PersonalityList.jsx
@@ -5,6 +5,8 @@ import api from "../../api/personality";
 import { Card, Row, Col, Pagination } from "antd";
 import "./PersonalityList.css";
 import AffixButton from "../Form/AffixButton";
+import { withTranslation } from "react-i18next";
+import PersonalityCard from "./PersonalityCard";
 
 const { Meta } = Card;
 
@@ -37,43 +39,33 @@ class PersonalityList extends Component {
 
         return (
             <>
-                <Row id="card" gutter="16   ">
-                    {personalities ? (
-                        <>
-                            {personalities.map((p, i) => (
-                                <Col span={8} key={i}>
-                                    <Link to={`personality/${p._id}`}>
-                                        <Card
-                                            hoverable
-                                            style={{
-                                                width: "100%",
-                                                margin: "8px 0"
-                                            }}
-                                        >
-                                            <Meta
-                                                title={p.name}
-                                                description={p.description}
-                                            />
-                                        </Card>
-                                    </Link>
-                                </Col>
-                            ))}
-                        </>
-                    ) : (
-                        <span>No results found</span>
-                    )}
-                </Row>
-                <Row id="pagination">
-                    <Col span={24}>
-                        <Pagination
-                            total={this.props.totalPages * this.props.pageSize}
-                            pageSize={this.props.pageSize}
-                            onChange={this.handlePagination.bind(this)}
-                            current={this.props.page}
-                        />
-                    </Col>
-                </Row>
-                <AffixButton onClick={this.createPersonality} />
+                {personalities ? (
+                    <>
+                        {personalities.map((p, i) => (
+                            <PersonalityCard
+                                personality={p}
+                                summarized={true}
+                                key={p._id}
+                            />
+                        ))}
+                        <Row id="pagination">
+                            <Col span={24}>
+                                <Pagination
+                                    total={
+                                        this.props.totalPages *
+                                        this.props.pageSize
+                                    }
+                                    pageSize={this.props.pageSize}
+                                    onChange={this.handlePagination.bind(this)}
+                                    current={this.props.page}
+                                />
+                            </Col>
+                        </Row>
+                        <AffixButton onClick={this.createPersonality} />
+                    </>
+                ) : (
+                    <span>No results found</span>
+                )}
             </>
         );
     }
@@ -86,4 +78,4 @@ const mapStateToProps = state => {
         totalPages: (state && state.searchTotalPages) || 1
     };
 };
-export default connect(mapStateToProps)(PersonalityList);
+export default connect(mapStateToProps)(withTranslation()(PersonalityList));

--- a/src/components/Personality/PersonalityView.jsx
+++ b/src/components/Personality/PersonalityView.jsx
@@ -1,77 +1,14 @@
 import React, { Component } from "react";
 import { withRouter } from "react-router-dom";
 import axios from "axios";
-import {
-    Divider,
-    Avatar,
-    Affix,
-    Comment,
-    Spin,
-    Table,
-    Button,
-    Col,
-    Row,
-    Typography,
-    Tooltip
-} from "antd";
-import { PlusOutlined } from "@ant-design/icons";
+import { Spin, Row } from "antd";
 
 import "./PersonalityView.css";
 import ReviewStats from "../ReviewStats";
-import ProfilePic from "./ProfilePic";
 import PersonalityCard from "./PersonalityCard";
 import { withTranslation } from "react-i18next";
 import AffixButton from "../Form/AffixButton";
-
-const { Title, Text, Paragraph } = Typography;
-const { Column } = Table;
-
-function ClaimCard(props) {
-    return (
-        <Col span={24}>
-            <Comment
-                style={{ margin: "0px 20px" }}
-                key={props.claimIndex}
-                author={props.personality.name}
-                avatar={
-                    <Avatar
-                        src={props.personality.image}
-                        alt={props.personality.name}
-                    />
-                }
-                content={
-                    <>
-                        <Row>
-                            <Col>
-                                <p>{props.claim.title}</p>
-                            </Col>
-                        </Row>
-                        <Row>
-                            <Col offset={16}>
-                                <Button
-                                    shape="round"
-                                    type="primary"
-                                    onClick={e => {
-                                        e.stopPropagation();
-                                        props.viewClaim(props.claim._id);
-                                    }}
-                                >
-                                    Revisar
-                                </Button>
-                            </Col>
-                        </Row>
-                    </>
-                }
-                datetime={
-                    <Tooltip title="01/2020">
-                        <span>há 5 meses</span>
-                    </Tooltip>
-                }
-            />
-            <hr style={{ opacity: "20%" }} />
-        </Col>
-    );
-}
+import ClaimCard from "../Claim/ClaimCard";
 
 class PersonalityView extends Component {
     constructor(props) {

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -12,6 +12,9 @@ const resources = {
         header: {
             search_personality: "Search personality"
         },
+        personality: {
+            profile_button: "See profile"
+        },
         footer: {
             copyright: "Aletheia ©2020 Created by Open Tesseract"
         }
@@ -22,6 +25,9 @@ const resources = {
         },
         header: {
             search_personality: "Busque uma personalidade"
+        },
+        personality: {
+            profile_button: "Veja o perfil"
         },
         footer: {
             copyright: "Aletheia ©2020 Criado por Open Tesseract"


### PR DESCRIPTION
Merge after https://github.com/OpenTesseract/aletheia/pull/113 is merged

1) Move ClaimCard to its own file
2) Use new data from personality endpoint and comply to the UI specs for
the personality card
3) Add i18n for the personality profile button
4) Apply changes to personality card at the home page