### PR TITLE
feat(vscode): Add tasks.json to speed up dev build

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,17 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "yarn",
+            "type": "shell",
+            "command": "yarn && yarn build && yarn dev:server & yarn dev:front",
+            "problemMatcher": [],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        }
+    ]
+}


### PR DESCRIPTION
As a good part of the team is using VS Code, I think it is useful to
execute just one command to get the project ready to work.

The default shortcut in VS Code is `Ctrl` + `Shift` + `B`. In my case, I
assigned it to the `F6` key. It is really quite useful.

## Command executed by `tasks.json`

``` sh
yarn \
  && yarn build \
  && yarn dev:server \
  & yarn dev:front
```

## Reference

- [&&' vs. '&' with the 'test' command in Bash](https://stackoverflow.com/a/26770612/1096219)

## Screenshot

![image](https://user-images.githubusercontent.com/993684/84406618-29c4aa80-abe0-11ea-88be-197f90ccb906.png)