### PR TITLE
claim: Edit page

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "domino": "^2.1.0",
     "draft-js": ">=0.10.0",
     "draft-js-export-html": "^1.4.1",
+    "draft-js-import-html": "^1.4.1",
     "express": "^4.16.4",
     "i18next": ">= 19.0.0",
     "i18next-browser-languagedetector": "^4.2.0",

--- a/server/api/repository/claim.ts
+++ b/server/api/repository/claim.ts
@@ -71,6 +71,8 @@ module.exports = class ClaimRepository {
         // eslint-disable-next-line no-useless-catch
         try {
             const claim = await this.getById(claimId);
+            const p = new Parser();
+            claimBody.content = p.parse(claimBody.content);
             const newClaim = Object.assign(claim, claimBody);
             const claimUpdate = await Claim.findByIdAndUpdate(
                 claimId,

--- a/server/api/repository/personality.ts
+++ b/server/api/repository/personality.ts
@@ -97,6 +97,9 @@ module.exports = class PersonalityRepository {
 
     private static extractClaimWithTextSummary(claims: any) {
         return claims.map(claim => {
+            if (!claim.content) {
+                return claim;
+            }
             return { ...claim, content: claim.content.text };
         });
     }

--- a/server/lib/parser.ts
+++ b/server/lib/parser.ts
@@ -47,7 +47,8 @@ class Parser {
                 });
             }
         }
-        return { object: result, text };
+        // TODO: check security for html content
+        return { object: result, text, html };
     }
 
     /**

--- a/src/App.js
+++ b/src/App.js
@@ -52,6 +52,13 @@ class App extends Component {
                                 path="/personality/:id/claim/:claimId"
                                 component={ClaimView}
                             />
+                            <Route
+                                exact
+                                path="/personality/:id/claim/:claimId/edit"
+                                render={props => (
+                                    <ClaimCreate {...props} edit={true} />
+                                )}
+                            />
                         </Switch>
                     </Router>
                 </Content>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3662,6 +3662,21 @@ draft-js-export-html@^1.4.1:
   dependencies:
     draft-js-utils "^1.4.0"
 
+draft-js-import-element@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/draft-js-import-element/-/draft-js-import-element-1.4.0.tgz#8760acbfeb60ed824a1c8319ec049f702681df66"
+  integrity sha512-WmYT5PrCm47lGL5FkH6sRO3TTAcn7qNHsD3igiPqLG/RXrqyKrqN4+wBgbcT2lhna/yfWTRtgzAbQsSJoS1Meg==
+  dependencies:
+    draft-js-utils "^1.4.0"
+    synthetic-dom "^1.4.0"
+
+draft-js-import-html@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/draft-js-import-html/-/draft-js-import-html-1.4.1.tgz#c222a3a40ab27dee5874fcf78526b64734fe6ea4"
+  integrity sha512-KOZmtgxZriCDgg5Smr3Y09TjubvXe7rHPy/2fuLSsL+aSzwUDwH/aHDA/k47U+WfpmL4qgyg4oZhqx9TYJV0tg==
+  dependencies:
+    draft-js-import-element "^1.4.0"
+
 draft-js-utils@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/draft-js-utils/-/draft-js-utils-1.4.0.tgz#c60af198108f69b0f1df3572555b23836819d1cf"
@@ -10225,6 +10240,11 @@ symbol-tree@^3.2.2:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
+
+synthetic-dom@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/synthetic-dom/-/synthetic-dom-1.4.0.tgz#d988d7a4652458e2fc8706a875417af913e4dd34"
+  integrity sha512-mHv51ZsmZ+ShT/4s5kg+MGUIhY7Ltq4v03xpN1c8T1Krb5pScsh/lzEjyhrVD0soVDbThbd2e+4dD9vnDG4rhg==
 
 table@^5.2.3:
   version "5.4.6"


### PR DESCRIPTION
1) Make ClaimCreate able to receive a boolean prop to indicate whether
the component should render in edit mode or not
2) Store html for Claim again in order to restore the right EditorState
when editing the claim
3) Apply parser to content submitted through PUT endpoint for claim
4) Bonus: Fix error in personality list endpoint

PS: The edit page is avaible but not exposed in the UI yet.