### PR TITLE
177234274/claim list

### DIFF
--- a/server/api/controller/claimController.ts
+++ b/server/api/controller/claimController.ts
@@ -10,9 +10,9 @@ export default class ClaimController {
         this.claimRepository = new ClaimRepository(logger);
     }
 
-    async listAll(query) {
+    listAll(query) {
         const { page = 0, pageSize = 10, order = "asc" } = query;
-        const queryInputs = await this.verifyInputsQuery(query);
+        const queryInputs = this.verifyInputsQuery(query);
 
         return Promise.all([
             this.claimRepository.listAll(

--- a/server/api/repository/claim.ts
+++ b/server/api/repository/claim.ts
@@ -2,7 +2,6 @@ import Parser from "../../lib/parser";
 import { ILogger } from "../../lib/loggerInterface";
 import ClaimReviewRepository from "./claimReview";
 
-const util = require("../../lib/util");
 const Claim = require("../model/claimModel");
 const Personality = require("../model/personalityModel");
 

--- a/server/api/repository/claim.ts
+++ b/server/api/repository/claim.ts
@@ -29,8 +29,8 @@ export default class ClaimRepository {
             .sort({ _id: order })
             .lean();
         return Promise.all(
-            claims.map(async claim => {
-                return await this.postProcess(claim);
+            claims.map(claim => {
+                return this.postProcess(claim);
             })
         );
     }

--- a/server/api/repository/claim.ts
+++ b/server/api/repository/claim.ts
@@ -20,8 +20,16 @@ export default class ClaimRepository {
         };
     }
 
-    listAll() {
-        return Claim.find({}).lean();
+    listAll(page, pageSize, order, query) {
+        return Claim.find(query)
+            .skip(page * pageSize)
+            .limit(pageSize)
+            .sort({ _id: order })
+            .lean();
+    }
+
+    count(query) {
+        return Claim.countDocuments().where(query);
     }
 
     create(claim) {

--- a/server/api/repository/claim.ts
+++ b/server/api/repository/claim.ts
@@ -1,31 +1,39 @@
 import Parser from "../../lib/parser";
 import { ILogger } from "../../lib/loggerInterface";
+import ClaimReviewRepository from "./claimReview";
 
-const Claim = require("../model/claimModel");
-const ClaimReview = require("../model/claimReviewModel");
-const Personality = require("../model/personalityModel");
 const util = require("../../lib/util");
+const Claim = require("../model/claimModel");
+const Personality = require("../model/personalityModel");
+
 /**
  * @class ClaimRepository
  */
 export default class ClaimRepository {
     optionsToUpdate: Object;
     logger: ILogger;
+    private claimReviewRepository: ClaimReviewRepository;
 
     constructor(logger: any = {}) {
         this.logger = logger;
+        this.claimReviewRepository = new ClaimReviewRepository(logger);
         this.optionsToUpdate = {
             new: true,
             upsert: true
         };
     }
 
-    listAll(page, pageSize, order, query) {
-        return Claim.find(query)
+    async listAll(page, pageSize, order, query) {
+        const claims = await Claim.find(query)
             .skip(page * pageSize)
             .limit(pageSize)
             .sort({ _id: order })
             .lean();
+        return Promise.all(
+            claims.map(async claim => {
+                return await this.postProcess(claim);
+            })
+        );
     }
 
     count(query) {
@@ -64,59 +72,14 @@ export default class ClaimRepository {
             // TODO: handle 404 for claim not found
             return {};
         }
-        const reviews = await ClaimReview.aggregate([
-            { $match: { claim: claim._id } },
-            {
-                $group: {
-                    _id: "$sentence_hash",
-                    topClassification: {
-                        $accumulator: {
-                            init: function() {
-                                return {};
-                            },
-                            accumulate: function(state, classification) {
-                                if (!state[classification]) {
-                                    state[classification] = 1;
-                                } else {
-                                    state[classification]++;
-                                }
 
-                                return state;
-                            },
-                            accumulateArgs: ["$classification"],
-                            merge: function(state1, state2) {
-                                return { ...state1, ...state2 };
-                            },
-                            finalize: function(state) {
-                                // Find the classification with bigger count
-                                const topClassification = Object.keys(
-                                    state
-                                ).reduce((acc, classification) => {
-                                    if (!state[acc]) {
-                                        return classification;
-                                    } else {
-                                        return state[acc] >=
-                                            state[classification]
-                                            ? acc
-                                            : classification;
-                                    }
-                                }, "");
-                                // TODO: what can we do about ties?
-                                return {
-                                    classification: topClassification,
-                                    count: state[topClassification]
-                                };
-                            },
-                            lang: "js"
-                        }
-                    }
-                }
-            }
-        ]).option({ serializeFunctions: true });
-        return this.postProcess(claim.toObject(), reviews);
+        return this.postProcess(claim.toObject());
     }
 
-    private async postProcess(claim, reviews) {
+    private async postProcess(claim) {
+        const reviews = await this.claimReviewRepository.getReviewsByClaimId(
+            claim._id
+        );
         if (claim) {
             if (claim?.content?.object) {
                 claim.content.object = this.transformContentObject(
@@ -124,7 +87,9 @@ export default class ClaimRepository {
                     reviews
                 );
             }
-            const reviewStats = await this.getReviewStats(claim._id);
+            const reviewStats = await this.claimReviewRepository.getReviewStatsByClaimId(
+                claim._id
+            );
             const overallStats = this.calculateOverallStats(claim);
             const stats = { ...reviewStats, ...overallStats };
             claim = Object.assign(claim, { stats });
@@ -171,15 +136,6 @@ export default class ClaimRepository {
             });
         });
         return claimContent;
-    }
-
-    async getReviewStats(id) {
-        const reviews = await ClaimReview.aggregate([
-            { $match: { claim: id } },
-            { $group: { _id: "$classification", count: { $sum: 1 } } },
-            { $sort: { count: -1 } }
-        ]);
-        return util.formatStats(reviews);
     }
 
     async update(claimId, claimBody) {

--- a/server/api/repository/claimReview.ts
+++ b/server/api/repository/claimReview.ts
@@ -1,5 +1,6 @@
 import { ILogger } from "../../lib/loggerInterface";
 
+const util = require("../../lib/util");
 const ClaimReview = require("../model/claimReviewModel");
 const Claim = require("../model/claimModel");
 const Source = require("../model/sourceModel");
@@ -56,6 +57,67 @@ export default class ClaimReviewRepository {
         return ClaimReview.findById(claimReviewId)
             .populate("claims", "_id title")
             .populate("sources", "_id link classification");
+    }
+
+    getReviewsByClaimId(claimId) {
+        return ClaimReview.aggregate([
+            { $match: { claim: claimId } },
+            {
+                $group: {
+                    _id: "$sentence_hash",
+                    topClassification: {
+                        $accumulator: {
+                            init: function() {
+                                return {};
+                            },
+                            accumulate: function(state, classification) {
+                                if (!state[classification]) {
+                                    state[classification] = 1;
+                                } else {
+                                    state[classification]++;
+                                }
+
+                                return state;
+                            },
+                            accumulateArgs: ["$classification"],
+                            merge: function(state1, state2) {
+                                return { ...state1, ...state2 };
+                            },
+                            finalize: function(state) {
+                                // Find the classification with bigger count
+                                const topClassification = Object.keys(
+                                    state
+                                ).reduce((acc, classification) => {
+                                    if (!state[acc]) {
+                                        return classification;
+                                    } else {
+                                        return state[acc] >=
+                                            state[classification]
+                                            ? acc
+                                            : classification;
+                                    }
+                                }, "");
+                                // TODO: what can we do about ties?
+                                return {
+                                    classification: topClassification,
+                                    count: state[topClassification]
+                                };
+                            },
+                            lang: "js"
+                        }
+                    }
+                }
+            }
+        ]).option({ serializeFunctions: true });
+    }
+
+    async getReviewStatsByClaimId(claimId) {
+        const reviews = await ClaimReview.aggregate([
+            { $match: { claim: claimId } },
+            { $group: { _id: "$classification", count: { $sum: 1 } } },
+            { $sort: { count: -1 } }
+        ]);
+        return util.formatStats(reviews);
     }
 
     async update(claimReviewId, claimReviewBody) {

--- a/server/api/repository/personality.ts
+++ b/server/api/repository/personality.ts
@@ -1,8 +1,7 @@
-import util from "../../lib/util";
-
 import { ILogger } from "../../lib/loggerInterface";
 import WikidataResolver from "../../lib/wikidataResolver";
 
+const util = require("../../lib/util");
 const Personality = require("../model/personalityModel");
 const ClaimReview = require("../model/claimReviewModel");
 
@@ -23,27 +22,6 @@ export default class PersonalityRepository {
         };
     }
 
-    /**
-     * https://medium.com/javascript-in-plain-english/javascript-merge-duplicate-objects-in-array-of-objects-9a76c3a1c35c
-     * @param array
-     * @param property
-     */
-    mergeObjectsInUnique<T>(array: T[], property: any): T[] {
-        const newArray = new Map();
-
-        array.forEach((item: T) => {
-            const propertyValue = item[property];
-            newArray.has(propertyValue)
-                ? newArray.set(propertyValue, {
-                      ...item,
-                      ...newArray.get(propertyValue)
-                  })
-                : newArray.set(propertyValue, item);
-        });
-
-        return Array.from(newArray.values());
-    }
-
     async listAll(
         page,
         pageSize,
@@ -62,7 +40,7 @@ export default class PersonalityRepository {
                 query.name.$regex,
                 language
             );
-            personalities = this.mergeObjectsInUnique(
+            personalities = util.mergeObjectsInUnique(
                 [...wbentities, ...personalities],
                 "wikidata"
             );

--- a/server/lib/swagger-ui.js
+++ b/server/lib/swagger-ui.js
@@ -2,7 +2,7 @@ const util = require("util");
 const fs = require("fs");
 const readFileAsync = util.promisify(fs.readFile);
 const path = require("path");
-const HTTPError = require("../lib/util.js").HTTPError;
+const HTTPError = require("./util").HTTPError;
 
 // Swagger-ui-dist helpfully exporting the absolute path of its dist directory
 const docRoot = `${require("swagger-ui-dist").getAbsoluteFSPath()}/`;

--- a/server/lib/util.ts
+++ b/server/lib/util.ts
@@ -32,7 +32,30 @@ function formatStats(reviews, slice = false) {
     });
     return { total, reviews: slice ? result.slice(0, 3) : result };
 }
+
+/**
+ * https://medium.com/javascript-in-plain-english/javascript-merge-duplicate-objects-in-array-of-objects-9a76c3a1c35c
+ * @param array
+ * @param property
+ */
+function mergeObjectsInUnique<T>(array: T[], property: any): T[] {
+    const newArray = new Map();
+
+    array.forEach((item: T) => {
+        const propertyValue = item[property];
+        newArray.has(propertyValue)
+            ? newArray.set(propertyValue, {
+                  ...item,
+                  ...newArray.get(propertyValue)
+              })
+            : newArray.set(propertyValue, item);
+    });
+
+    return Array.from(newArray.values());
+}
+
 module.exports = {
     router: createRouter,
-    formatStats
+    formatStats,
+    mergeObjectsInUnique
 };

--- a/server/routes/claim.js
+++ b/server/routes/claim.js
@@ -12,6 +12,19 @@ const router = require("../lib/util").router();
 let app;
 
 /**
+ * GET {domain}/personality
+ */
+router.get("/", (req, res, next) => {
+    const claim = new ClaimController(app);
+    claim
+        .listAll(req.query)
+        .then(result => res.send(result))
+        .catch(error => {
+            next(Requester.internalError(res, error.message, app.logger));
+        });
+});
+
+/**
  * POST {domain}/claim
  */
 router.post("/", ensureLoggedIn, async (req, res, next) => {

--- a/src/api/claim.js
+++ b/src/api/claim.js
@@ -3,6 +3,31 @@ import { message } from "antd";
 
 const baseUrl = `${process.env.API_URL}/claim`;
 
+const get = (options = {}) => {
+    const params = {
+        page: options.page - 1,
+        name: options.searchName,
+        pageSize: options.pageSize,
+        personality: options.personality
+    };
+
+    return axios
+        .get(`${process.env.API_URL}/claim`, { params })
+        .then(response => {
+            const { claims, totalPages, totalClaims } = response.data;
+            if (options.fetchOnly) {
+                return {
+                    data: claims,
+                    total: totalClaims,
+                    totalPages
+                };
+            }
+        })
+        .catch(e => {
+            throw e;
+        });
+};
+
 const getById = (id, params = {}) => {
     return axios
         .get(`${baseUrl}/${id}`, {
@@ -61,6 +86,7 @@ const update = (id, params = {}) => {
 };
 
 export default {
+    get,
     getById,
     save,
     update

--- a/src/api/personality.js
+++ b/src/api/personality.js
@@ -14,7 +14,6 @@ const getPersonalities = (options = {}, dispatch) => {
     return axios
         .get(`${process.env.API_URL}/personality`, { params })
         .then(response => {
-            console.log(response.data);
             const {
                 personalities,
                 totalPages,

--- a/src/components/Claim/ClaimCard.jsx
+++ b/src/components/Claim/ClaimCard.jsx
@@ -8,22 +8,10 @@ import ReviewColors from "../../constants/reviewColors";
 
 const { Paragraph } = Typography;
 class ClaimCard extends Component {
-    constructor(props) {
-        super(props);
-        this.state = {};
-    }
-    async componentDidMount() {
-        const claim = await api.getById(this.props.claim._id);
-        this.setState({
-            claim: Object.assign(claim, {
-                content: this.props.claim.content
-            })
-        });
-    }
     render() {
         const { t } = this.props;
-        const review = this.state.claim?.stats?.reviews[0];
-        if (this.state.claim) {
+        const review = this.props.claim?.stats?.reviews[0];
+        if (this.props.claim) {
             return (
                 <Col span={24}>
                     <Comment
@@ -46,14 +34,14 @@ class ClaimCard extends Component {
                                             }}
                                         >
                                             "
-                                            {this.state.claim.content.text ||
-                                                this.state.claim.title}
+                                            {this.props.claim.content.text ||
+                                                this.props.claim.title}
                                             "
                                         </Paragraph>
                                         <Link
                                             to={location =>
                                                 this.props.viewClaim(
-                                                    this.state.claim._id,
+                                                    this.props.claim._id,
                                                     true
                                                 )
                                             }
@@ -73,7 +61,7 @@ class ClaimCard extends Component {
                                             }}
                                         >
                                             {t("claim:metricsHeaderInfo", {
-                                                totalReviews: this.state.claim
+                                                totalReviews: this.props.claim
                                                     ?.stats?.total
                                             })}
                                         </span>{" "}
@@ -113,7 +101,7 @@ class ClaimCard extends Component {
                                             onClick={e => {
                                                 e.stopPropagation();
                                                 this.props.viewClaim(
-                                                    this.state.claim._id
+                                                    this.props.claim._id
                                                 );
                                             }}
                                         >
@@ -124,8 +112,8 @@ class ClaimCard extends Component {
                             </>
                         }
                         datetime={
-                            <Tooltip title={this.state.claim?.date}>
-                                <span>{this.state.claim?.date}</span>
+                            <Tooltip title={this.props.claim?.date}>
+                                <span>{this.props.claim?.date}</span>
                             </Tooltip>
                         }
                     />

--- a/src/components/Claim/ClaimCard.jsx
+++ b/src/components/Claim/ClaimCard.jsx
@@ -28,7 +28,6 @@ class ClaimCard extends Component {
                 <Col span={24}>
                     <Comment
                         review="true"
-                        key={this.props.claimIndex}
                         author={this.props.personality.name}
                         avatar={
                             <Avatar
@@ -47,7 +46,7 @@ class ClaimCard extends Component {
                                             }}
                                         >
                                             "
-                                            {this.state.claim.content ||
+                                            {this.state.claim.content.text ||
                                                 this.state.claim.title}
                                             "
                                         </Paragraph>

--- a/src/components/Claim/ClaimList.jsx
+++ b/src/components/Claim/ClaimList.jsx
@@ -1,0 +1,41 @@
+import React, { Component } from "react";
+import claim from "../../api/claim";
+import BaseList from "../List/BaseList";
+import ClaimCard from "./ClaimCard";
+import { withRouter } from "react-router-dom";
+
+class ClaimList extends Component {
+    constructor(props) {
+        super(props);
+        this.viewClaim = this.viewClaim.bind(this);
+    }
+    viewClaim(id, link = false) {
+        const path = `./${this.props.match.params.id}/claim/${id}`;
+        if (!link) {
+            this.props.history.push(path);
+        } else {
+            return path;
+        }
+    }
+
+    render() {
+        const { personality } = this.props;
+        return (
+            <BaseList
+                apiCall={claim.get}
+                query={{ personality: personality._id }}
+                renderItem={claim =>
+                    claim && (
+                        <ClaimCard
+                            key={claim._id}
+                            personality={personality}
+                            claim={claim}
+                            viewClaim={this.viewClaim}
+                        />
+                    )
+                }
+            />
+        );
+    }
+}
+export default withRouter(ClaimList);

--- a/src/components/Claim/ClaimList.jsx
+++ b/src/components/Claim/ClaimList.jsx
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import claim from "../../api/claim";
+import claimApi from "../../api/claim";
 import BaseList from "../List/BaseList";
 import ClaimCard from "./ClaimCard";
 import { withRouter } from "react-router-dom";
@@ -22,7 +22,7 @@ class ClaimList extends Component {
         const { personality } = this.props;
         return (
             <BaseList
-                apiCall={claim.get}
+                apiCall={claimApi.get}
                 query={{ personality: personality._id }}
                 renderItem={claim =>
                     claim && (

--- a/src/components/List/BaseList.jsx
+++ b/src/components/List/BaseList.jsx
@@ -10,10 +10,12 @@ class BaseList extends Component {
             query: {
                 page: 1,
                 pageSize: 10,
-                fetchOnly: true
+                fetchOnly: true,
+                ...(props.query || {})
             },
             items: []
         };
+
         this.loadMore = this.loadMore.bind(this);
     }
     componentDidMount() {

--- a/src/components/List/BaseList.jsx
+++ b/src/components/List/BaseList.jsx
@@ -123,7 +123,7 @@ class BaseList extends Component {
                     ></Spin>
                 );
             } else {
-                return emptyFallback;
+                return emptyFallback || null;
             }
         }
     }

--- a/src/components/Personality/PersonalityList.jsx
+++ b/src/components/Personality/PersonalityList.jsx
@@ -20,22 +20,20 @@ class PersonalityList extends Component {
             </Row>
         );
         return (
-            <>
-                <BaseList
-                    apiCall={api.getPersonalities}
-                    emptyFallback={createPersonalityCTA}
-                    renderItem={p =>
-                        p && (
-                            <PersonalityCard
-                                personality={p}
-                                summarized={true}
-                                key={p._id}
-                            />
-                        )
-                    }
-                    footer={createPersonalityCTA}
-                />
-            </>
+            <BaseList
+                apiCall={api.getPersonalities}
+                emptyFallback={createPersonalityCTA}
+                renderItem={p =>
+                    p && (
+                        <PersonalityCard
+                            personality={p}
+                            summarized={true}
+                            key={p._id}
+                        />
+                    )
+                }
+                footer={createPersonalityCTA}
+            />
         );
     }
 }

--- a/src/components/Personality/PersonalityView.jsx
+++ b/src/components/Personality/PersonalityView.jsx
@@ -6,19 +6,19 @@ import api from "../../api/personality";
 import "./PersonalityView.less";
 import PersonalityCard from "./PersonalityCard";
 import AffixButton from "../Form/AffixButton";
-import ClaimCard from "../Claim/ClaimCard";
+import ClaimList from "../Claim/ClaimList";
 
 class PersonalityView extends Component {
     constructor(props) {
         super(props);
         this.createClaim = this.createClaim.bind(this);
-        this.viewClaim = this.viewClaim.bind(this);
         this.state = {};
         this.tooltipVisible = true;
         setTimeout(() => {
             this.tooltipVisible = false;
         }, 2500);
     }
+
     componentDidUpdate(prevProps) {
         if (prevProps.match.params.id !== this.props.match.params.id) {
             this.getPersonality();
@@ -44,15 +44,6 @@ class PersonalityView extends Component {
         this.props.history.push(path);
     }
 
-    viewClaim(id, link = false) {
-        const path = `./${this.props.match.params.id}/claim/${id}`;
-        if (!link) {
-            this.props.history.push(path);
-        } else {
-            return path;
-        }
-    }
-
     render() {
         const personality = this.state.personality;
         const { t } = this.props;
@@ -65,18 +56,7 @@ class PersonalityView extends Component {
                         tooltipTitle={t("personality:affixButtonTitle")}
                         onClick={this.createClaim}
                     />
-                    <Row style={{ background: "white" }}>
-                        {personality.claims.map((claim, claimIndex) => {
-                            return (
-                                <ClaimCard
-                                    key={claimIndex}
-                                    personality={personality}
-                                    claim={claim}
-                                    viewClaim={this.viewClaim}
-                                />
-                            );
-                        })}
-                    </Row>
+                    <ClaimList personality={personality}></ClaimList>
                 </>
             );
         } else {


### PR DESCRIPTION
1. Add server functionality to list query Claims
2. Add call to new endpoint in the client-site api call
3. Fix bug with ClaimCard introduced by latest change in the endpoint
4. Add query prop to the BaseList components so lists can perform custom queries
5. Extract Claims list in PersonalityView page into ClaimList component extending BaseList
6.  Refactor claim repository to execute postProcess on listAll and move code that doesn't belong to this module to either util or claim review repository. Refactor personality repository too.
7.  Remove extra call in ClaimCard now that the claim list endpoint is returning all the needed data. Return null in BaseList if no emptyCallback React node is provided